### PR TITLE
Add .vagrant to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant


### PR DESCRIPTION
Prevents git from picking up the `.vagrant` directory that gets created when bringing up our vagrant learning environment with `vagrant up`