### PR TITLE
Update groups.lb variable in e47-rolling.yml

### DIFF
--- a/examples/e47-rolling.yml
+++ b/examples/e47-rolling.yml
@@ -23,7 +23,7 @@
   - name: disable server in haproxy
     shell: echo "disable server episode46/{{ inventory_hostname }}" | socat stdio /var/lib/haproxy/stats
     delegate_to: "{{ item }}"
-    with_items: groups.lb
+    with_items: "{{ groups.lb }}"
 
   tasks:
 
@@ -57,7 +57,7 @@
   - name: enable server in haproxy
     shell: echo "enable server episode46/{{ inventory_hostname }}" | socat stdio /var/lib/haproxy/stats
     delegate_to: "{{ item }}"
-    with_items: groups.lb
+    with_items: "{{ groups.lb }}"
 
 # lb
 - hosts: lb


### PR DESCRIPTION
The previous syntax does not appear to work correctly with ansible 2.3.1.0. 

I don't have full documentation to support my suspicion, but this looks like bug 13584. Referenced at the following: https://github.com/ansible/ansible/issues/13584