### PR TITLE
broken config file

### DIFF
--- a/examples/templates/haproxy.cfg.j2
+++ b/examples/templates/haproxy.cfg.j2
@@ -36,7 +36,8 @@ defaults
 
 backend app
     {% for host in groups['lb'] %}
-       listen episode46 {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:80
+       listen episode46 
+           bind {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:80
     {% endfor %}
     balance     roundrobin
     {% for host in groups['web'] %}


### PR DESCRIPTION
Initial config file of haproxy needed. I'm using Ubuntu 16.04 so maybe that is issue, but anyway it works fine with changes which i'm offering.
haproxy(version 1.6.3 2015/12/25) doesn't restart because if such error in journalctl -xe

-- Unit haproxy.service has finished shutting down.
Jan 10 10:12:17 lb haproxy[1466]: [ALERT] 009/101217 (1466) : parsing [/etc/haproxy/haproxy.cfg:38] : 'listen' cannot handle unexpected argument 'http://10.0.2.15:80'.
Jan 10 10:12:17 lb haproxy[1466]: [ALERT] 009/101217 (1466) : parsing [/etc/haproxy/haproxy.cfg:38] : please use the 'bind' keyword for listening addresses.
Jan 10 10:12:17 lb haproxy[1466]: [ALERT] 009/101217 (1466) : Error(s) found in configuration file : /etc/haproxy/haproxy.cfg
Jan 10 10:12:17 lb haproxy[1466]: [ALERT] 009/101217 (1466) : Fatal errors found in configuration.
Jan 10 10:12:17 lb systemd[1]: Starting HAProxy Load Balancer...
-- Subject: Unit haproxy.service has begun start-up
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has begun starting up.
Jan 10 10:12:17 lb systemd[1]: haproxy.service: Control process exited, code=exited status=1
Jan 10 10:12:17 lb systemd[1]: Failed to start HAProxy Load Balancer.
-- Subject: Unit haproxy.service has failed
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has failed.
-- 
-- The result is failed.
Jan 10 10:12:17 lb systemd[1]: haproxy.service: Unit entered failed state.
Jan 10 10:12:17 lb systemd[1]: haproxy.service: Failed with result 'exit-code'.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Service hold-off time over, scheduling restart.
Jan 10 10:12:18 lb systemd[1]: Stopped HAProxy Load Balancer.
-- Subject: Unit haproxy.service has finished shutting down
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has finished shutting down.
Jan 10 10:12:18 lb systemd[1]: Starting HAProxy Load Balancer...
-- Subject: Unit haproxy.service has begun start-up
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has begun starting up.
Jan 10 10:12:18 lb haproxy[1470]: [ALERT] 009/101218 (1470) : parsing [/etc/haproxy/haproxy.cfg:38] : 'listen' cannot handle unexpected argument 'http://10.0.2.15:80'.
Jan 10 10:12:18 lb haproxy[1470]: [ALERT] 009/101218 (1470) : parsing [/etc/haproxy/haproxy.cfg:38] : please use the 'bind' keyword for listening addresses.
Jan 10 10:12:18 lb haproxy[1470]: [ALERT] 009/101218 (1470) : Error(s) found in configuration file : /etc/haproxy/haproxy.cfg
Jan 10 10:12:18 lb haproxy[1470]: [ALERT] 009/101218 (1470) : Fatal errors found in configuration.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Control process exited, code=exited status=1
Jan 10 10:12:18 lb systemd[1]: Failed to start HAProxy Load Balancer.
-- Subject: Unit haproxy.service has failed
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has failed.
-- 
-- The result is failed.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Unit entered failed state.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Failed with result 'exit-code'.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Service hold-off time over, scheduling restart.
Jan 10 10:12:18 lb systemd[1]: Stopped HAProxy Load Balancer.
-- Subject: Unit haproxy.service has finished shutting down
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has finished shutting down.
Jan 10 10:12:18 lb systemd[1]: Starting HAProxy Load Balancer...
-- Subject: Unit haproxy.service has begun start-up
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has begun starting up.
Jan 10 10:12:18 lb haproxy[1475]: [ALERT] 009/101218 (1475) : parsing [/etc/haproxy/haproxy.cfg:38] : 'listen' cannot handle unexpected argument 'http://10.0.2.15:80'.
Jan 10 10:12:18 lb haproxy[1475]: [ALERT] 009/101218 (1475) : parsing [/etc/haproxy/haproxy.cfg:38] : please use the 'bind' keyword for listening addresses.
Jan 10 10:12:18 lb haproxy[1475]: [ALERT] 009/101218 (1475) : Error(s) found in configuration file : /etc/haproxy/haproxy.cfg
Jan 10 10:12:18 lb haproxy[1475]: [ALERT] 009/101218 (1475) : Fatal errors found in configuration.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Control process exited, code=exited status=1
Jan 10 10:12:18 lb systemd[1]: Failed to start HAProxy Load Balancer.
-- Subject: Unit haproxy.service has failed
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has failed.
-- 
-- The result is failed.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Unit entered failed state.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Failed with result 'exit-code'.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Service hold-off time over, scheduling restart.
Jan 10 10:12:18 lb systemd[1]: Stopped HAProxy Load Balancer.
-- Subject: Unit haproxy.service has finished shutting down
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has finished shutting down.
Jan 10 10:12:18 lb systemd[1]: Starting HAProxy Load Balancer...
-- Subject: Unit haproxy.service has begun start-up
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has begun starting up.
Jan 10 10:12:18 lb haproxy[1480]: [ALERT] 009/101218 (1480) : parsing [/etc/haproxy/haproxy.cfg:38] : 'listen' cannot handle unexpected argument 'http://10.0.2.15:80'.
Jan 10 10:12:18 lb haproxy[1480]: [ALERT] 009/101218 (1480) : parsing [/etc/haproxy/haproxy.cfg:38] : please use the 'bind' keyword for listening addresses.
Jan 10 10:12:18 lb haproxy[1480]: [ALERT] 009/101218 (1480) : Error(s) found in configuration file : /etc/haproxy/haproxy.cfg
Jan 10 10:12:18 lb haproxy[1480]: [ALERT] 009/101218 (1480) : Fatal errors found in configuration.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Control process exited, code=exited status=1
Jan 10 10:12:18 lb systemd[1]: Failed to start HAProxy Load Balancer.
-- Subject: Unit haproxy.service has failed
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has failed.
-- 
-- The result is failed.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Unit entered failed state.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Failed with result 'exit-code'.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Service hold-off time over, scheduling restart.
Jan 10 10:12:18 lb systemd[1]: Stopped HAProxy Load Balancer.
-- Subject: Unit haproxy.service has finished shutting down
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has finished shutting down.
Jan 10 10:12:18 lb systemd[1]: haproxy.service: Start request repeated too quickly.
Jan 10 10:12:18 lb systemd[1]: Failed to start HAProxy Load Balancer.
-- Subject: Unit haproxy.service has failed
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit haproxy.service has failed.
-- 
-- The result is failed.